### PR TITLE
Include docs/contents.rst in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include docs/index.rst
+include docs/contents.rst
 include guesslang/data/*
 include guesslang/data/model/*
 include guesslang/data/model/variables/*


### PR DESCRIPTION
This file is loaded in `setup.py` so needs to be included in the source distribution in order for this package to be installable from sdist.

### Before

```
$ python setup.py sdist
running sdist
[...]
creating dist
Creating tar archive
removing 'guesslang-2.2.2' (and everything under it)

$ pip install dist/guesslang-2.2.2.tar.gz
Looking in indexes: http://169.254.255.254:20641/bionic/simple/
Processing ./dist/guesslang-2.2.2.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /tmp/tmp.KtuVJX7wkl/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-qnxek_k0/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-qnxek_k0/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-9np76lgt
         cwd: /tmp/pip-req-build-qnxek_k0/
    Complete output (15 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-qnxek_k0/setup.py", line 56, in <module>
        'https://guesslang.readthedocs.io/en/latest/',
      File "/tmp/pip-req-build-qnxek_k0/setup.py", line 37, in long_description
        for line in Path(filename).read_text().splitlines():
      File "/usr/lib/python3.6/pathlib.py", line 1196, in read_text
        with self.open(mode='r', encoding=encoding, errors=errors) as f:
      File "/usr/lib/python3.6/pathlib.py", line 1183, in open
        opener=self._opener)
      File "/usr/lib/python3.6/pathlib.py", line 1037, in _opener
        return self._accessor.open(self, flags, mode)
      File "/usr/lib/python3.6/pathlib.py", line 387, in wrapped
        return strfunc(str(pathobj), *args)
    FileNotFoundError: [Errno 2] No such file or directory: 'docs/contents.rst'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

```

### After

```
$ python setup.py sdist
running sdist
[...]
creating dist
Creating tar archive
removing 'guesslang-2.2.2' (and everything under it)

$ pip install dist/guesslang-2.2.2.tar.gz
Looking in indexes: http://169.254.255.254:20641/bionic/simple/
Processing ./dist/guesslang-2.2.2.tar.gz
Collecting tensorflow
[...]
Successfully built guesslang
Installing collected packages: urllib3, [...], guesslang
Successfully installed absl-py-0.12.0 [...] zipp-3.3.0
```